### PR TITLE
[Logger] Logger formatting patch

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BuildView.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BuildView.java
@@ -410,7 +410,7 @@ public class BuildView {
               "Analysis succeeded for only %d of %d top-level targets",
               numSuccessful, numTargetsToAnalyze);
       eventHandler.handle(Event.info(msg));
-      logger.atInfo().log(msg);
+      logger.atInfo().log("%s", msg);
     }
 
     AnalysisResult result;

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
@@ -163,7 +163,7 @@ public abstract class BuildEventServiceModule<BESOptionsT extends BuildEventServ
     // Don't hide unchecked exceptions as part of the error reporting.
     Throwables.throwIfUnchecked(exception);
 
-    logger.atSevere().withCause(exception).log(msg);
+    logger.atSevere().withCause(exception).log("%s", msg);
     reportCommandLineError(commandLineReporter, exception);
     moduleEnvironment.exit(createAbruptExitException(exception, msg, besCode));
   }
@@ -254,7 +254,7 @@ public abstract class BuildEventServiceModule<BESOptionsT extends BuildEventServ
                   + "Cancelling and starting a new invocation...",
               waitedMillis / 1000, waitedMillis % 1000);
       reporter.handle(Event.warn(msg));
-      logger.atWarning().withCause(exception).log(msg);
+      logger.atWarning().withCause(exception).log("%s", msg);
       cancelCloseFutures = true;
     } catch (ExecutionException e) {
       String msg;
@@ -274,7 +274,7 @@ public abstract class BuildEventServiceModule<BESOptionsT extends BuildEventServ
                 e.getMessage());
       }
       reporter.handle(Event.warn(msg));
-      logger.atWarning().withCause(e).log(msg);
+      logger.atWarning().withCause(e).log("%s", msg);
       cancelCloseFutures = true;
     } finally {
       if (cancelCloseFutures) {
@@ -671,7 +671,7 @@ public abstract class BuildEventServiceModule<BESOptionsT extends BuildEventServ
           String.format(
               "Build Event Service uploads disabled due to a connectivity problem: %s", status);
       reporter.handle(Event.warn(message));
-      logger.atWarning().log(message);
+      logger.atWarning().log("%s", message);
       return null;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceUploader.java
@@ -293,7 +293,7 @@ public final class BuildEventServiceUploader implements Runnable {
 
   private DetailedExitCode logAndSetException(
       String message, BuildProgress.Code bpCode, Throwable cause) {
-    logger.atSevere().log(message);
+    logger.atSevere().log("%s", message);
     DetailedExitCode detailedExitCode =
         DetailedExitCode.of(
             FailureDetail.newBuilder()
@@ -490,7 +490,7 @@ public final class BuildEventServiceUploader implements Runnable {
                       String.format(
                           "Expected ACK with seqNum=%d but received ACK with seqNum=%d",
                           expected.getSequenceNumber(), actualSeqNum);
-                  logger.atInfo().log(message);
+                  logger.atInfo().log("%s", message);
                   streamContext.abortStream(Status.FAILED_PRECONDITION.withDescription(message));
                 }
               } else {
@@ -498,7 +498,7 @@ public final class BuildEventServiceUploader implements Runnable {
                     String.format(
                         "Received ACK (seqNum=%d) when no ACK was expected",
                         ackEvent.getSequenceNumber());
-                logger.atInfo().log(message);
+                logger.atInfo().log("%s", message);
                 streamContext.abortStream(Status.FAILED_PRECONDITION.withDescription(message));
               }
             }
@@ -537,7 +537,7 @@ public final class BuildEventServiceUploader implements Runnable {
               if (!shouldRetryStatus(streamStatus)) {
                 String message =
                     String.format("Not retrying publishBuildEvents: status='%s'", streamStatus);
-                logger.atInfo().log(message);
+                logger.atInfo().log("%s", message);
                 throw withFailureDetail(
                     streamStatus.asException(),
                     BuildProgress.Code.BES_STREAM_NOT_RETRYING_FAILURE,
@@ -548,7 +548,7 @@ public final class BuildEventServiceUploader implements Runnable {
                     String.format(
                         "Not retrying publishBuildEvents, no more attempts left: status='%s'",
                         streamStatus);
-                logger.atInfo().log(message);
+                logger.atInfo().log("%s", message);
                 throw withFailureDetail(
                     streamStatus.asException(),
                     BuildProgress.Code.BES_UPLOAD_RETRY_LIMIT_EXCEEDED_FAILURE,
@@ -636,7 +636,7 @@ public final class BuildEventServiceUploader implements Runnable {
         if (!shouldRetryStatus(e.getStatus())) {
           String message =
               String.format("Not retrying publishLifecycleEvent: status='%s'", e.getStatus());
-          logger.atInfo().log(message);
+          logger.atInfo().log("%s", message);
           throw withFailureDetail(e, BuildProgress.Code.BES_STREAM_NOT_RETRYING_FAILURE, message);
         }
 

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/FileTransport.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/FileTransport.java
@@ -186,7 +186,7 @@ abstract class FileTransport implements BuildEventTransport {
                       .build()),
               e));
       pendingWrites.clear();
-      logger.atSevere().withCause(e).log(message);
+      logger.atSevere().withCause(e).log("%s", message);
     }
 
     private static BuildProgress.Code getBuildProgressCode(Throwable e) {

--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -578,7 +578,7 @@ public class ExecutionTool {
         for (Path entry : entries) {
           directoryDetails.append(" '").append(entry.getBaseName()).append("'");
         }
-        logger.atWarning().log(directoryDetails.toString());
+        logger.atWarning().log("%s", directoryDetails);
       } catch (IOException e) {
         logger.atWarning().withCause(e).log("'%s' exists but could not be read", directory);
       }

--- a/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
@@ -251,7 +251,7 @@ public class LocalSpawnRunner implements SpawnRunner {
         Level level, @Nullable Throwable cause, @FormatString String fmt, Object... args) {
       String msg = String.format(fmt, args);
       String toLog = String.format("%s (#%d %s)", msg, id, desc());
-      logger.at(level).withCause(cause).log(toLog);
+      logger.at(level).withCause(cause).log("%s", toLog);
     }
 
     private String desc() {

--- a/src/main/java/com/google/devtools/build/lib/platform/SystemSuspensionModule.java
+++ b/src/main/java/com/google/devtools/build/lib/platform/SystemSuspensionModule.java
@@ -59,7 +59,7 @@ public final class SystemSuspensionModule extends BlazeModule {
       String logString = event.logString();
       reporter.handle(Event.info(logString));
       reporter.post(event);
-      logger.atInfo().log(logString);
+      logger.atInfo().log("%s", logString);
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -868,7 +868,7 @@ public final class RemoteModule extends BlazeModule {
       failure = e;
       failureCode = Code.RPC_LOG_FAILURE;
       failureMessage = "Partially wrote rpc log file";
-      logger.atWarning().withCause(e).log(failureMessage);
+      logger.atWarning().withCause(e).log("%s", failureMessage);
     }
 
     executorService = null;

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
@@ -274,7 +274,7 @@ public final class BlazeOptionHandler {
       StarlarkOptionsParser.newStarlarkOptionsParser(env, optionsParser).parse(eventHandler);
     } catch (OptionsParsingException e) {
       String logMessage = "Error parsing Starlark options";
-      logger.atInfo().withCause(e).log(logMessage);
+      logger.atInfo().withCause(e).log("%s", logMessage);
       return processOptionsParsingException(
           eventHandler, e, logMessage, Code.STARLARK_OPTIONS_PARSE_FAILURE);
     }
@@ -343,7 +343,7 @@ public final class BlazeOptionHandler {
       }
     } catch (OptionsParsingException e) {
       String logMessage = "Error parsing options";
-      logger.atInfo().withCause(e).log(logMessage);
+      logger.atInfo().withCause(e).log("%s", logMessage);
       return processOptionsParsingException(
           eventHandler, e, logMessage, Code.OPTIONS_PARSE_FAILURE);
     } catch (InterruptedException e) {

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
@@ -947,7 +947,7 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
 
     try {
       logger.atInfo().log(
-          SafeRequestLogging.getRequestLogString(commandLineOptions.getOtherArgs()));
+          "%s", SafeRequestLogging.getRequestLogString(commandLineOptions.getOtherArgs()));
       BlazeCommandResult result =
           dispatcher.exec(
               policy,

--- a/src/main/java/com/google/devtools/build/lib/runtime/BuildSummaryStatsModule.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BuildSummaryStatsModule.java
@@ -138,7 +138,7 @@ public class BuildSummaryStatsModule extends BlazeModule {
           event.getResult().getBuildToolLogCollection()
               .addDirectValue(
                   "critical path", criticalPath.toString().getBytes(StandardCharsets.UTF_8));
-          logger.atInfo().log(criticalPath.toString());
+          logger.atInfo().log("%s", criticalPath);
           logger.atInfo().log(
               "Slowest actions:\n  %s",
               Joiner.on("\n  ").join(criticalPathComputer.getSlowestComponents()));

--- a/src/main/java/com/google/devtools/build/lib/server/GrpcServerImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/server/GrpcServerImpl.java
@@ -545,7 +545,7 @@ public class GrpcServerImpl extends CommandServerGrpc.CommandServerImplBase impl
             .collect(ImmutableList.toImmutableList());
 
         InvocationPolicy policy = InvocationPolicyParser.parsePolicy(request.getInvocationPolicy());
-        logger.atInfo().log(SafeRequestLogging.getRequestLogString(args));
+        logger.atInfo().log("%s", SafeRequestLogging.getRequestLogString(args));
         result =
             dispatcher.exec(
                 policy,

--- a/src/main/java/com/google/devtools/build/lib/server/ShutdownHooks.java
+++ b/src/main/java/com/google/devtools/build/lib/server/ShutdownHooks.java
@@ -84,6 +84,6 @@ public class ShutdownHooks {
     printErr.println("=======[BAZEL SERVER: ENCOUNTERED IO EXCEPTION]=======");
     e.printStackTrace(printErr);
     printErr.println("=====================================================");
-    logger.atSevere().log(err.toString());
+    logger.atSevere().log("%s", err);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/shell/Command.java
+++ b/src/main/java/com/google/devtools/build/lib/shell/Command.java
@@ -410,7 +410,7 @@ public final class Command implements DescribableExecutionUnit {
   }
 
   private static void processInput(InputStream stdinInput, Subprocess process) {
-    logger.atFiner().log(stdinInput.toString());
+    logger.atFiner().log("%s", stdinInput);
     try (OutputStream out = process.getOutputStream()) {
       ByteStreams.copy(stdinInput, out);
     } catch (IOException ioe) {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SequencedSkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SequencedSkyframeExecutor.java
@@ -651,7 +651,7 @@ public final class SequencedSkyframeExecutor extends SkyframeExecutor {
       }
     }
 
-    logger.atInfo().log(result.toString());
+    logger.atInfo().log("%s", result);
   }
 
   private static int getNumberOfModifiedFiles(Iterable<SkyKey> modifiedValues) {

--- a/src/tools/android/java/com/google/devtools/build/android/desugar/testing/junit/DesugarRunner.java
+++ b/src/tools/android/java/com/google/devtools/build/android/desugar/testing/junit/DesugarRunner.java
@@ -267,7 +267,7 @@ public final class DesugarRunner extends BlockJUnit4ClassRunner {
 
     @Override
     public void evaluate() throws Throwable {
-      logger.atWarning().log(reason);
+      logger.atWarning().log("%s", reason);
     }
 
     @Override

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
@@ -331,7 +331,7 @@ final class ExecutionServer extends ExecutionImplBase {
             String.format(
                 "Command:\n%s\nexceeded deadline of %f seconds.",
                 Arrays.toString(command.getArgumentsList().toArray()), timeoutMillis / 1000.0);
-        logger.atWarning().log(errMessage);
+        logger.atWarning().log("%s", errMessage);
         errStatus =
             Status.newBuilder()
                 .setCode(Code.DEADLINE_EXCEEDED.getNumber())


### PR DESCRIPTION
Loggers were facing this issue:
```
error: [FloggerLogString] Arguments to log(String) must be compile-time constants or parameters annotated with @CompileTimeConstant. If possible, use Flogger's formatting log methods instead.
```
Solution was to update the formatting